### PR TITLE
Strict Encryption

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -222,7 +222,8 @@ const SocketOption srt_options [] {
     { "payloadsize", 0, SRTO_PAYLOADSIZE, SocketOption::PRE, SocketOption::INT, nullptr},
     { "transtype", 0, SRTO_TRANSTYPE, SocketOption::PRE, SocketOption::ENUM, &enummap_transtype },
     { "kmrefreshrate", 0, SRTO_KMREFRESHRATE, SocketOption::PRE, SocketOption::INT, nullptr },
-    { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr },
+    { "strictenc", 0, SRTO_STRICTENC, SocketOption::PRE, SocketOption::BOOL, nullptr }
 };
 }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -559,6 +559,7 @@ private: // Identification
     int m_iOPT_PeerTsbPdDelay;       // Peer's Rx latency for the traffic made by Agent's Tx.
     bool m_bOPT_TLPktDrop;           // Whether Agent WILL DO TLPKTDROP on Rx.
     int m_iOPT_SndDropDelay;         // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
+    bool m_bOPT_StrictEncryption;    // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     std::string m_sStreamName;
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -286,6 +286,7 @@ int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen,
     return SRT_CMD_KMRSP;
 
 HSv4_ErrorReport:
+    srtlen = 1;
 
     if (bidirectional && hasPassphrase())
     {
@@ -311,6 +312,8 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
     size_t srtlen = len/sizeof(uint32_t);
     HtoNLA(srtd, srtdata, srtlen);
 
+    int retstatus = -1;
+
     // Unused?
     //bool bidirectional = hsv > CUDT::HS_VERSION_UDT4;
 
@@ -328,6 +331,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
         {
         case SRT_KM_S_BADSECRET:
             m_SndKmState = m_RcvKmState = SRT_KM_S_BADSECRET;
+            retstatus = -1;
             break;
 
             // Default embraces two cases:
@@ -338,6 +342,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
             // This means that the peer did not set the password, while Agent did.
             m_RcvKmState = SRT_KM_S_UNSECURED;
             m_SndKmState = SRT_KM_S_NOSECRET;
+            retstatus = -1;
             break;
 
         case SRT_KM_S_UNSECURED:
@@ -346,6 +351,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
             // but can't decrypt what Peer would send.
             m_RcvKmState = SRT_KM_S_NOSECRET;
             m_SndKmState = SRT_KM_S_UNSECURED;
+            retstatus = 0;
             break;
 
         default:
@@ -353,6 +359,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
                     << KmStateStr(peerstate) << " (" << int(peerstate) << ")");
             m_RcvKmState = SRT_KM_S_NOSECRET;
             m_SndKmState = SRT_KM_S_NOSECRET;
+            retstatus = -1; //This is IPE
             break;
         }
 
@@ -371,9 +378,11 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
         {
             m_SndKmState = m_RcvKmState = SRT_KM_S_SECURED;
             HLOGC(mglog.Debug, log << "processSrtMsg_KMRSP: KM response matches " << (key1 ? "EVEN" : "ODD") << " key");
+            retstatus = 1;
         }
         else
         {
+            retstatus = -1;
             LOGC(mglog.Error, log << "processSrtMsg_KMRSP: IPE??? KM response key matches no key");
             /* XXX INSECURE
             LOGC(mglog.Error, log << "processSrtMsg_KMRSP: KM response: [" << FormatBinaryString((uint8_t*)srtd, len)
@@ -389,7 +398,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
 
     LOGP(mglog.Note, FormatKmMessage("processSrtMsg_KMRSP", SRT_CMD_KMRSP, len));
 
-    return SRT_CMD_NONE;
+    return retstatus;
 }
 
 void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen)

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -115,6 +115,11 @@ public:
 
     // Detailed processing
     int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, uint32_t* srtdata_out, ref_t<size_t> r_srtlen, int hsv);
+
+    // This returns:
+    // 1 - the given payload is the same as the currently used key
+    // 0 - there's no key in agent or the payload is error message with agent NOSECRET.
+    // -1 - the payload is error message with other state or it doesn't match the key
     int processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int hsv);
     void createFakeSndContext();
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -172,13 +172,14 @@ typedef enum SRT_SOCKOPT {
     SRTO_RCVLATENCY,      // TsbPd receiver delay (mSec) to absorb burst of missed packet retransmission
     SRTO_PEERLATENCY,     // Minimum value of the TsbPd receiver delay (mSec) for the opposite side (peer)
     SRTO_MINVERSION,      // Minimum SRT version needed for the peer (peers with less version will get connection reject)
-    SRTO_STREAMID,         // A string set to a socket and passed to the listener's accepted socket
-    SRTO_SMOOTHER,         // Smoother selection (congestion control algorithm)
-    SRTO_MESSAGEAPI,
-    SRTO_PAYLOADSIZE,
-    SRTO_TRANSTYPE,         // Transmission type (set of options required for given transmission type)
-    SRTO_KMREFRESHRATE,
-    SRTO_KMPREANNOUNCE
+    SRTO_STREAMID,        // A string set to a socket and passed to the listener's accepted socket
+    SRTO_SMOOTHER,        // Smoother selection (congestion control algorithm)
+    SRTO_MESSAGEAPI,      // In File mode, use message API (portions of data with boundaries)
+    SRTO_PAYLOADSIZE,     // Maximum payload size sent in one UDP packet (0 if unlimited)
+    SRTO_TRANSTYPE,       // Transmission type (set of options required for given transmission type)
+    SRTO_KMREFRESHRATE,   // After sending how many packets the encryption key should be flipped to the new key
+    SRTO_KMPREANNOUNCE,   // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
+    SRTO_STRICTENC,       // Connection to be rejected or quickly broken when one side encryption set or bad password
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:


### PR DESCRIPTION
This adds a new option SRTO_STRICTENC. When set to true, in the case of abnormal encryption settings, the connection is rejected.

Abnormal encryption settings are when:

    only one side sets the encryption
    both sides set different passwords

The non-strict encryption behavior (this flag off, the so far behavior) was that:

    the side that set no encryption could still send unencrypted payload
    the side that set encryption is allowed to send the encrypted payload, just uselessly, because it can't be decrypted

The value for SRTO_STRICTENC is true by default. This means that the old behavior must be explicitly enforced by clearing this flag.