### PR TITLE
CEPollDesc::m_iID is now initialized in the constructor

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1056,8 +1056,9 @@ Creates a new epoll container.
 
 - Errors:
 
-  * `SRT_ECONNSETUP`: System operation failed. This is on systems that use a 
-special method for the system part of epoll and therefore associated resources,
+  * `SRT_ECONNSETUP`: System operation failed or not enough space to create a new epoll.
+System error might happen on systems that use a 
+special method for the system part of epoll (`epoll_create()`, `kqueue()`), and therefore associated resources,
 like epoll on Linux.
 
 ### srt_epoll_add_usock, srt_epoll_add_ssock, srt_epoll_update_usock, srt_epoll_update_ssock

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -529,17 +529,17 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
                 //"select" has a limitation on the number of sockets
                 int max_fd = 0;
 
-                fd_set readfds;
-                fd_set writefds;
-                FD_ZERO(&readfds);
-                FD_ZERO(&writefds);
+                fd_set rqreadfds;
+                fd_set rqwritefds;
+                FD_ZERO(&rqreadfds);
+                FD_ZERO(&rqwritefds);
 
                 for (set<SYSSOCKET>::const_iterator i = ed.m_sLocals.begin(); i != ed.m_sLocals.end(); ++ i)
                 {
                     if (lrfds)
-                        FD_SET(*i, &readfds);
+                        FD_SET(*i, &rqreadfds);
                     if (lwfds)
-                        FD_SET(*i, &writefds);
+                        FD_SET(*i, &rqwritefds);
                     if ((int)*i > max_fd)
                         max_fd = *i;
                 }
@@ -547,16 +547,16 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
                 timeval tv;
                 tv.tv_sec = 0;
                 tv.tv_usec = 0;
-                if (::select(max_fd + 1, &readfds, &writefds, NULL, &tv) > 0)
+                if (::select(max_fd + 1, &rqreadfds, &rqwritefds, NULL, &tv) > 0)
                 {
                     for (set<SYSSOCKET>::const_iterator i = ed.m_sLocals.begin(); i != ed.m_sLocals.end(); ++ i)
                     {
-                        if (lrfds && FD_ISSET(*i, &readfds))
+                        if (lrfds && FD_ISSET(*i, &rqreadfds))
                         {
                             lrfds->insert(*i);
                             ++ total;
                         }
-                        if (lwfds && FD_ISSET(*i, &writefds))
+                        if (lwfds && FD_ISSET(*i, &rqwritefds))
                         {
                             lwfds->insert(*i);
                             ++ total;

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -62,7 +62,7 @@ modified by
 
 struct CEPollDesc
 {
-   int m_iID;                                // epoll ID
+   const int m_iID;                                // epoll ID
 
    struct Wait;
 
@@ -137,8 +137,10 @@ private:
 
 public:
 
-   CEPollDesc():
-       m_Flags(0)
+   CEPollDesc(int id, int localID)
+       : m_iID(id)
+       , m_Flags(0)
+       , m_iLocalID(localID)
     {
     }
 
@@ -164,7 +166,7 @@ public:
    enotice_t::iterator enotice_begin() { return m_USockEventNotice.begin(); }
    enotice_t::iterator enotice_end() { return m_USockEventNotice.end(); }
 
-   int m_iLocalID;                           // local system epoll ID
+   const int m_iLocalID;                           // local system epoll ID
    std::set<SYSSOCKET> m_sLocals;            // set of local (non-UDT) descriptors
 
    std::pair<ewatch_t::iterator, bool> addWatch(SRTSOCKET sock, int32_t events, bool edgeTrg)


### PR DESCRIPTION
`CEPollDesc::m_iID` was not initialized in the constructor.
In the code it was initialized right away, after the object is created.

- [x] Made `CEPollDesc::m_iID` and `CEPollDesc::m_iLocalID` constant.
- [x] Throw exception when new `CEPollDesc` is created with an ID, that already existed.
- [x] [core] Fixed `epoll` local variables names. Local variables 'readfds' and 'writefds' shadow outer argument.